### PR TITLE
Set mc-curseforge-api to v1.0.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "various.authors <various.authors@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "mc-curseforge-api": "^1.0.6",
+    "mc-curseforge-api": "=1.0.6",
     "mem-fs": "^1.1.3",
     "mem-fs-editor": "^6.0.0",
     "nickjs": "^0.3.7",


### PR DESCRIPTION
Set the package version for mc-curseforge-api fixed to v1.0.6 because version 2.0.0 got released and the chance of breaking is farely high.